### PR TITLE
Prevent dependency errors while doing vagrant up

### DIFF
--- a/puppet/site_magece.pp
+++ b/puppet/site_magece.pp
@@ -2,6 +2,10 @@ Exec {
   path => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 }
 
+Package {
+  require => Exec['apt-get_update'],
+}
+
 class { 'magece':
   directory     => '/var/www/magece',
   repository    => 'svn',


### PR DESCRIPTION
make sure apt-get update is executed when initiating the magentoce module
