### PR TITLE
Prevent dependency errors while doing vagrant up for shopware vm

### DIFF
--- a/puppet/site_shopware.pp
+++ b/puppet/site_shopware.pp
@@ -2,6 +2,10 @@ Exec {
   path => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 }
 
+Package {
+  require => Exec['apt-get_update'],
+}
+
 class { 'shopware':
   directory     => '/var/www/shopware',
   repository    => 'git',


### PR DESCRIPTION
same error and fix as for magentoce vm
